### PR TITLE
Add instructions to README and restructure xpub documentation a little bit

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,10 @@
 # Development for documentation
 
-Version: Python 3.7 (`brew install python@3.7` & `brew link --overwrite python@3.7`)
+Version: Python 3.7 (`brew install python@3.7 && brew link --overwrite python@3.7`)
 
 Install Sphinx Autobuild: `pip3 install sphinx-autobuild`
+
+Install Sphinx theme: `pip3 install sphinx_rtd_theme`
 
 Run: `python3 /usr/local/bin/sphinx-autobuild . _build/html --port 10000`
 

--- a/docs/xpub-withdraw.rst
+++ b/docs/xpub-withdraw.rst
@@ -14,7 +14,7 @@ Configuring a XPUB
 ------------------
 For the sake of demonstration, we'll be using the following XPUB here:
 
-.. code-block::
+.. code-block:: bash
    :caption: /home/bob/.bitcoin-dca
 
    WITHDRAW_XPUB=zpub6rLtzSoXnXKPXHroRKGCwuRVHjgA5YL6oUkdZnCfbDLdtAKNXb1FX1EmPUYR1uYMRBpngvkdJwxqhLvM46trRy5MRb7oYdSLbb4w5VC4i3z
@@ -27,7 +27,7 @@ Verifying the configured XPUB
 
 You can verify that Bitcoin DCA will derive the correct addresses using the following command:
 
-.. code-block::
+.. code-block:: bash
    :caption: Verifying the configured XPUB
 
    $ docker run --rm -it --env-file=/home/bob/.bitcoin-dca-bobby jorijn/bitcoin-dca:latest verify-xpub
@@ -46,11 +46,12 @@ You can verify that Bitcoin DCA will derive the correct addresses using the foll
    │ 9 │ bc1q2ufc8j9uw6x7hwqfsdakungk63etanxtkplel0 │               │
    └───┴────────────────────────────────────────────┴───────────────┘
 
-   [WARNING] Make sure these addresses match those in your client, do not use the withdraw function if they do not.
+.. note:: 
+   Make sure these addresses match those in your client, do not use the withdraw function if they do not.
 
 You can check that the correct address is being used when attempting to withdraw your Bitcoin:
 
-.. code-block::
+.. code-block:: bash
    :caption: Here, it takes address #0 (bc1qvqatyv2xynyanrej2fcutj6w5yugy0gc9jx2nn) for withdrawal
 
    $ docker run --rm -it --env-file=/home/bob/.bitcoin-dca-bobby jorijn/bitcoin-dca:latestwithdraw --all


### PR DESCRIPTION
On a new install the sphinx_rtd_theme is missing. Added instructions for installing it via pip3.

Should fix #50 as well.