### PR TITLE
Get fee based on trading schedule

### DIFF
--- a/src/Service/Kraken/KrakenBuyService.php
+++ b/src/Service/Kraken/KrakenBuyService.php
@@ -135,7 +135,7 @@ class KrakenBuyService implements BuyServiceInterface
     protected function getTakerFeeFromSchedule(): int
     {
         $feeSchedule = $this->client->queryPrivate('TradeVolume', ['pair' => $this->tradingPair, 'fee_info' => 'true']);
-        $feePercentage = current($feeSchedule['fees'])['fee'];
+        $feePercentage = current($feeSchedule['fees'])['fee'] ?? 0;
         $feePercentage *= 10000;
 
         return (int) $feePercentage;

--- a/src/Service/Kraken/KrakenBuyService.php
+++ b/src/Service/Kraken/KrakenBuyService.php
@@ -129,12 +129,13 @@ class KrakenBuyService implements BuyServiceInterface
     }
 
     /**
-     * Returns the fee percentage, taker side. Multiplied by 10000 to ensure rounded integer. 0.26 -> 2600.
+     * Returns the fee percentage based on the trading volume over the last 30 days, taker side.
+     * Multiplied by 10000 to ensure rounded integer. 0.26 -> 2600.
      */
     protected function getTakerFeeFromSchedule(): int
     {
-        $feeSchedule = $this->client->queryPublic('AssetPairs', ['pair' => $this->tradingPair, 'info' => 'fees']);
-        $feePercentage = $feeSchedule[array_key_first($feeSchedule)]['fees'][0][1] ?? 0;
+        $feeSchedule = $this->client->queryPrivate('TradeVolume', ['pair' => $this->tradingPair, 'fee_info' => 'true']);
+        $feePercentage = current($feeSchedule['fees'])['fee'];
         $feePercentage *= 10000;
 
         return (int) $feePercentage;

--- a/tests/Service/Kraken/KrakenBuyServiceTest.php
+++ b/tests/Service/Kraken/KrakenBuyServiceTest.php
@@ -321,7 +321,7 @@ final class KrakenBuyServiceTest extends TestCase
             ->willReturnOnConsecutiveCalls(
                 [
                     'fees' => [
-                        'XXBTZEUR' => [
+                        'XBT'.$this->baseCurrency => [
                             'fee' => $takerFeePercentage,
                         ],
                     ],

--- a/tests/Service/Kraken/KrakenBuyServiceTest.php
+++ b/tests/Service/Kraken/KrakenBuyServiceTest.php
@@ -291,22 +291,21 @@ final class KrakenBuyServiceTest extends TestCase
         $fee = (string) ($expectedAmount * $takerFeePercentage / 100);
 
         $this->client
-            ->expects(static::exactly(2))
+            ->expects(static::exactly(1))
             ->method('queryPublic')
             ->withConsecutive(
                 ['Ticker', ['pair' => 'XBT'.$this->baseCurrency]],
-                ['AssetPairs', ['pair' => 'XBT'.$this->baseCurrency, 'info' => 'fees']]
             )
             ->willReturnOnConsecutiveCalls(
                 ['XBT' => ['a' => [$price]]],
-                ['XBT'.$this->baseCurrency => ['fees' => [[0, $takerFeePercentage]]]]
             )
         ;
 
         $this->client
-            ->expects(static::exactly(3))
+            ->expects(static::exactly(4))
             ->method('queryPrivate')
             ->withConsecutive(
+                ['TradeVolume', ['pair' => 'XBT'.$this->baseCurrency, 'fee_info' => 'true']],
                 [
                     'AddOrder',
                     static::callback(function ($options) use ($expectedAmount, $price) {
@@ -320,6 +319,13 @@ final class KrakenBuyServiceTest extends TestCase
                 ['TradesHistory'],
             )
             ->willReturnOnConsecutiveCalls(
+                [
+                    'fees' => [
+                        'XXBTZEUR' => [
+                            'fee' => $takerFeePercentage,
+                        ],
+                    ],
+                ],
                 ['txid' => [$txId]], // add order call
                 [[]], // open orders call
                 [


### PR DESCRIPTION
Get the taker-fee from the users trading schedule. Instead of using the highest fee for this trading pair, use the actual taker-fee that applies based on the trading volume over the last 30 days.

https://docs.kraken.com/rest/#operation/getTradeVolume

Only affects you when you trade more than 50,000.00 USD in 30 days.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/1370548/144097737-2c15781f-ce54-42c3-bbe1-b37adc5520a1.png">
